### PR TITLE
Add LLM-assisted Codex pattern discovery

### DIFF
--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -68,6 +68,6 @@ Regularly revisit this document as new patterns emerge. The automation in this r
 
 # Callouts
 
-- DO NOT IMPLEMENT FALLBACKS. If you are unsure how to do something or something isn't working. Do not introduce quick fallbacks to make your life easier like using mocked data or assuming something isn't possible or calculating things in memory
-- Prefer rg (ripgrep) over grep
-- Leverage all your MCP tools, specially Serena and repomix
+- DO NOT IMPLEMENT FALLBACKS. If you are unsure how to do something or something isn't working, avoid quick hacks like mocked data or assuming functionality is impossible; pause and surface the blocker instead.
+- Prefer rg (ripgrep) over grep for searching.
+- Leverage MCP tools—including Serena and Repomix—before resorting to manual spelunking.

--- a/.github/workflows/codex-pattern-dry-run.yml
+++ b/.github/workflows/codex-pattern-dry-run.yml
@@ -1,0 +1,31 @@
+name: Codex Pattern Dry Run
+
+on:
+  push:
+    branches: [ master, codex/autotune ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run Codex pattern analyzer (dry run)
+        env:
+          CODEX_PATTERN_DISABLE_LLM: '1'
+        run: |
+          python3 .codex/scripts/codex_pattern_updater.py \
+            --dry-run \
+            --skip-git \
+            --history tests/fixtures/history_sample.jsonl \
+            --state /tmp/state.json \
+            --codex /tmp/CODEX.md

--- a/tests/fixtures/history_sample.jsonl
+++ b/tests/fixtures/history_sample.jsonl
@@ -1,0 +1,4 @@
+{"session_id":"sample-1","ts":1757000000,"text":"Please document the change thoroughly and write a regression test."}
+{"session_id":"sample-1","ts":1757000100,"text":"Also summarize the validation steps once you're done."}
+{"session_id":"sample-2","ts":1757000200,"text":"You're editing the wrong directory; confirm the target path before writing."}
+{"session_id":"sample-2","ts":1757000300,"text":"Use rg to locate the existing implementation and update the README."}


### PR DESCRIPTION
## Summary
- enable codex_pattern_updater.py to augment static guidance with LLM-discovered patterns while keeping state under 100k tokens
- persist dynamic patterns in automation_state and regenerate CODEX.md with stable callouts
- teach the headless wrapper and cron job to keep working from master-derived branch

## Motivation
- static pattern list risked missing new failure modes; LLM suggestions keep guidance evolving automatically
- keeping state bounded avoids unbounded growth as sessions accumulate